### PR TITLE
Usa mfe-checkout nas rotas de checkout

### DIFF
--- a/src/routes/checkout.js
+++ b/src/routes/checkout.js
@@ -1,9 +1,9 @@
 const checkoutRoutes = {
-  CART: "checkout/cart",
-  CHECKOUT: "checkout",
-  CARDS: "checkout/cards",
-  COMPRAS: "checkout/purchases",
-  COMPRA: "checkout/purchases/:id",
+  CART: "/checkout/cart",
+  CHECKOUT: "/checkout/confirm",
+  CARDS: "/checkout/cards",
+  COMPRAS: "/checkout/purchases",
+  COMPRA: "/checkout/purchases/:id",
 };
 
 export default checkoutRoutes;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,4 @@
 import checkoutRoutes from "./checkout";
-import monolitoRoutes from "./monolito";
 import productsRoutes from "./products";
 import usersRoutes from "./users";
 
@@ -18,11 +17,11 @@ const routes = {
     PRODUTO: productsRoutes.PRODUTO,
 
     /* mfe-checkout */
-    CART: monolitoRoutes.CART,
-    CHECKOUT: monolitoRoutes.CHECKOUT,
-    CARDS: monolitoRoutes.CARDS,
-    COMPRAS: monolitoRoutes.COMPRAS,
-    COMPRA: monolitoRoutes.COMPRA,
+    CART: checkoutRoutes.CART,
+    CHECKOUT: checkoutRoutes.CHECKOUT,
+    CARDS: checkoutRoutes.CARDS,
+    COMPRAS: checkoutRoutes.COMPRAS,
+    COMPRA: checkoutRoutes.COMPRA,
 }
 
 export default routes;


### PR DESCRIPTION
# Descrição

Altera objeto `routes` para deixar de exportar o path das telas abaixo do monolito para agora exportar o path das telas no mfe-checkout:
- Cartões
- Modal de criar cartão
- Carrinho
- Checkout
- Compras
- Compra


## PRs relacionadas
- https://github.com/nabstore/mfe-checkout/pull/1